### PR TITLE
added path_list arg to TextFileStreamer

### DIFF
--- a/rosetta/text/streamers.py
+++ b/rosetta/text/streamers.py
@@ -204,7 +204,7 @@ class TextFileStreamer(BaseStreamer):
         self.tokenizer = tokenizer
         self.tokenizer_func = tokenizer_func
         self.shuffle = shuffle
-
+        assert (text_base_path is None) or (path_list is None)
         assert (tokenizer is None) or (tokenizer_func is None)
         if tokenizer_func:
             self.tokenizer = text_processors.MakeTokenizer(tokenizer_func)


### PR DESCRIPTION
Added an argument to TextFileStreamer to allow an explicit list of paths. Ex, you want only certain files in a dir and you know what those are. In this case it will not get_path()... 
