### PR TITLE
Bugfix: 'by' label in groupby_to_series_to_frame

### DIFF
--- a/rosetta/parallel/pandas_easy.py
+++ b/rosetta/parallel/pandas_easy.py
@@ -142,7 +142,7 @@ def groupby_to_series_to_frame(
     # Set the index
     if hasattr(groupby_kwargs['by'], 'name'):
         indexname = groupby_kwargs['by'].name
-    elif isinstance(groupby_kwargs['by'], str):
+    elif isinstance(groupby_kwargs['by'], basestring):
         indexname = groupby_kwargs['by']
     else:
         indexname = None

--- a/rosetta/parallel/pandas_easy.py
+++ b/rosetta/parallel/pandas_easy.py
@@ -142,6 +142,8 @@ def groupby_to_series_to_frame(
     # Set the index
     if hasattr(groupby_kwargs['by'], 'name'):
         indexname = groupby_kwargs['by'].name
+    elif isinstance(groupby_kwargs['by'], str):
+        indexname = groupby_kwargs['by']
     else:
         indexname = None
     concatted.index = pd.Index(labels, name=indexname)

--- a/rosetta/tests/test_parallel.py
+++ b/rosetta/tests/test_parallel.py
@@ -154,12 +154,6 @@ class TestPandasEasy(unittest.TestCase):
         pass
 
     def test_groupby_to_scalar_to_series_1(self):
-        df = pd.DataFrame({'a': [6, 2, 2], 'b': [4, 5, 6]})
-        benchmark = df.groupby('a').apply(max)
-        result = pandas_easy.groupby_to_scalar_to_series(df, max, 1, by='a')
-        assert_series_equal(result, benchmark)
-
-    def test_groupby_to_scalar_to_series_2(self):
         s = pd.Series([1, 2, 3, 4])
         labels = ['a', 'a', 'b', 'b']
         benchmark = s.groupby(labels).apply(max)
@@ -182,6 +176,13 @@ class TestPandasEasy(unittest.TestCase):
         result = pandas_easy.groupby_to_series_to_frame(
             df, frame_to_series, 1, use_apply=False, by=labels)
         assert_frame_equal(result, benchmark)
+
+    def test_groupby_to_series_to_frame_3(self):
+        df = pd.DataFrame({'a': [6, 2, 2], 'b': [4, 5, 6]})
+        benchmark = df.groupby('a').apply(max)
+        result = pandas_easy.groupby_to_series_to_frame(df, max, 1, by='a')
+        assert_frame_equal(result, benchmark)
+
 
 
 class TestLockIterateApply(unittest.TestCase):


### PR DESCRIPTION
This is in regard to this issue: https://github.com/columbia-applied-data-science/rosetta/issues/39

Now if one uses e.g. by = 'a', the resulting dataframe has the label set
as 'a' as it should. The failing test that precipitated this change was
updated to change its incorrect usage of groupby to series to groubpy to
frame.