### PR TITLE
Added encoding to utf-8 for writing out LDA results

### DIFF
--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -579,7 +579,7 @@ class LDAResults(object):
             outstr += "\n" + sorted_topic.to_string() + "\n"
 
         with smart_open(outfile, 'w') as f:
-            f.write(outstr)
+            f.write(outstr.encode('utf-8'))
 
     @property
     def pr_token_g_topic(self):


### PR DESCRIPTION
Before this addition, writing out to file sometimes threw a 

UnicodeEncodeError: 'ascii' codec can't encode character... error. 