### PR TITLE
Ldaresults

### DIFF
--- a/rosetta/tests/test_text.py
+++ b/rosetta/tests/test_text.py
@@ -582,14 +582,14 @@ class TestConverters(unittest.TestCase):
         else:
             sys.stdout.write('Please install unix utility pdftotext')
 
-        if cmd_exists('catdoc'):
+        if cmd_exists('antiword'):
             converters.file_to_txt(self.testdoc_path, self.testtemp_path)
             tempdoc_path = os.path.join(self.testtemp_path, 'test.txt')
             with open(tempdoc_path) as f:
                 self.assertTrue(isinstance(f, file))
             os.system('rm %s' % os.path.join(self.testtemp_path, 'test.txt'))
         else:
-            sys.stdout.write('Please install unix utility catdoc')
+            sys.stdout.write('Please install unix utility antiword')
 
         converters.file_to_txt(self.testpdf_path, self.testtemp_path)
         tempdocx_path = os.path.join(self.testtemp_path, 'test.txt')

--- a/rosetta/tests/test_text.py
+++ b/rosetta/tests/test_text.py
@@ -12,7 +12,7 @@ import pandas as pd
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 from rosetta.text import text_processors, vw_helpers, nlp, converters
-from rosetta.common import DocIDError
+from rosetta.common import DocIDError, TokenError
 
 
 class TestWordTokenizers(unittest.TestCase):
@@ -375,12 +375,12 @@ class TestLDAResults(unittest.TestCase):
         benchmark = pd.Series({'topic_0': 0.5, 'topic_1': 0.5})
         assert_allclose(results.values, benchmark.values, atol=1e-3)
 
-#     def test_predict_6(self):
-#         # Use fact that w0  <--> topic_0,  w1 <--> topic_1
-#         lda = self.choose_lda('lda_2')
-#         tokenized_text = ['newtoken', 'newtoken']
-#         with self.assertRaises(TokenError) as cm:
-#             results = lda.predict(tokenized_text, raise_on_unknown=True)
+    def test_predict_6(self):
+        # Use fact that w0  <--> topic_0,  w1 <--> topic_1
+        lda = self.choose_lda('lda_2')
+        tokenized_text = ['newtoken', 'newtoken']
+        with self.assertRaises(TokenError):
+            lda.predict(tokenized_text, raise_on_unknown=True)
 
     def tearDown(self):
         self.outfile.close()
@@ -517,11 +517,11 @@ class TestSFileFilter(unittest.TestCase):
             (self.hash_fun('word1'), self.hash_fun('word2')))
         self.assertEqual(result, benchmark)
 
-#     def test_filter_sfile_5(self):
-#         self.sff.load_sfile(self.sfile_1)
-#         with self.assertRaises(AssertionError) as cm:
-#             self.sff.filter_sfile(
-#                 self.sfile_1, self.outfile, doc_id_list=['doc1', 'unseen'])
+    def test_filter_sfile_5(self):
+        self.sff.load_sfile(self.sfile_1)
+        with self.assertRaises(AssertionError):
+            self.sff.filter_sfile(
+                self.sfile_1, self.outfile, doc_id_list=['doc1', 'unseen'])
 
     def test_filter_sfile_all_false_filter(self):
         self.sff.load_sfile(self.sfile_1)

--- a/rosetta/tests/test_text.py
+++ b/rosetta/tests/test_text.py
@@ -357,7 +357,7 @@ class TestLDAResults(unittest.TestCase):
         benchmark = pd.Series({'topic_0': 0.5, 'topic_1': 0.5})
         assert_allclose(results.values, benchmark.values, atol=1e-3)
 
-    def test_predict_4(self):
+    def test_predict_w_large_alpha(self):
         # Use fact that w0  <--> topic_0,  w1 <--> topic_1
         lda = self.choose_lda('lda_2')
         lda.alpha = 1000000
@@ -366,7 +366,7 @@ class TestLDAResults(unittest.TestCase):
         benchmark = pd.Series({'topic_0': 0.5, 'topic_1': 0.5})
         assert_allclose(results.values, benchmark.values, atol=1e-3)
 
-    def test_predict_5(self):
+    def test_predict_on_unkown_token(self):
         # Use fact that w0  <--> topic_0,  w1 <--> topic_1
         lda = self.choose_lda('lda_2')
         lda.alpha = 0.1
@@ -375,7 +375,7 @@ class TestLDAResults(unittest.TestCase):
         benchmark = pd.Series({'topic_0': 0.5, 'topic_1': 0.5})
         assert_allclose(results.values, benchmark.values, atol=1e-3)
 
-    def test_predict_6(self):
+    def test_raise_on_unkown_token(self):
         # Use fact that w0  <--> topic_0,  w1 <--> topic_1
         lda = self.choose_lda('lda_2')
         tokenized_text = ['newtoken', 'newtoken']

--- a/rosetta/text/converters.py
+++ b/rosetta/text/converters.py
@@ -16,8 +16,10 @@ from unidecode import unidecode
 ###############################################################################
 # Functions for converting various format files to .txt
 ###############################################################################
-def file_to_txt(file_path, dst_dir, new_file_name=None, ret_fname=False, 
-        clean_path=False):
+
+
+def file_to_txt(file_path, dst_dir, new_file_name=None, ret_fname=False,
+                clean_path=False):
     """
     Takes a file path and writes the file in txt format to dst_dir.
     If file is already .txt, then simply copies the file.
@@ -44,21 +46,23 @@ def file_to_txt(file_path, dst_dir, new_file_name=None, ret_fname=False,
         try:
             file_path = _filepath_clean(file_path)
         except IOError:
-            sys.stdout.write('unable to clean file_name %s \n'%file_path)
+            sys.stdout.write('unable to clean file_name %s \n' % file_path)
     file_name = os.path.split(file_path)[1]
     name, ext = os.path.splitext(file_name)
     ext = re.sub(r'\.', '', ext)
     if new_file_name:
         file_name = new_file_name
-    converter_func_name = '_%s_to_txt'%ext
+    converter_func_name = '_%s_to_txt' % ext
     if converter_func_name in globals().keys():
-        #calls one of the _to_txt()
-        out = eval(converter_func_name)(file_path, dst_dir, file_name) 
-        if out: sys.stdout.write('unable to process file %s'%file_path)
-        if ret_fname: return file_name
+        # calls one of the _to_txt()
+        out = eval(converter_func_name)(file_path, dst_dir, file_name)
+        if out:
+            sys.stdout.write('unable to process file %s' % file_path)
+        if ret_fname:
+            return file_name
     else:
-        sys.stdout.write('file type %s not supported, skipping %s \n'%(ext,
-            file_name))
+        sys.stdout.write('file type %s not supported, skipping %s \n' %
+                         (ext, file_name))
 
 
 def _filepath_clean(file_path):
@@ -179,10 +183,7 @@ def _rtf_to_txt(file_path, dst_dir, file_name):
     file_dst = os.path.join(dst_dir, re.sub(r'\.rtf$', '.txt', file_name))
     doc = Rtf15Reader.read(open(file_path))
     txt = PlaintextWriter.write(doc).getvalue()
-    txt = unidecode(txt)
+    txt = txt.decode('ascii')
     with open(file_dst, 'w') as f:
         f.write(txt)
     return 0
-
-
-

--- a/rosetta/text/converters.py
+++ b/rosetta/text/converters.py
@@ -137,20 +137,21 @@ def _pdf_to_txt(file_path, dst_dir, file_name):
 
 def _doc_to_txt(file_path, dst_dir, file_name):
     """
-    Uses catdoc unix util to convert file_name
+    Uses antiword unix util to convert file_name
     to .txt and save in dst_dir.
 
     Notes
     -----
-    To install catdoc:
-        apt-get catdoc on unix/linux
-        brew install on mac
+    To install antiword:
+        apt-get install antiword (on unix/linux)
+        brew install antiword (on mac)
     """
     if file_name is None:
         file_name = os.path.split(file_path)[1]
     file_dst = os.path.join(dst_dir, re.sub(r'\.doc$', '.txt', file_name))
     with open(file_dst, 'w') as f:
-        return subprocess.call(["catdoc",  "-w", file_path, file_dst], stdout=f)
+        return subprocess.call(["antiword", file_path, ">",  file_dst],
+                               stdout=f)
 
 
 def _docx_to_txt(file_path, dst_dir, file_name):

--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -321,16 +321,15 @@ class LDAResults(object):
         self._lambda_word_sums = topics.sum()
         self.pr_topic = self._lambda_word_sums / self._lambda_word_sums.sum()
 
-        # topic tokens
+        # tokens & topic
         word_sums = topics.sum(axis=1)
         self.pr_token = word_sums / word_sums.sum()
         self.pr_token_topic = topics / self._lambda_word_sums.sum()
         self.pr_token_topic.index.name = 'token'
 
-        # topic docs
+        # docs & topics
         doc_sums = predictions.sum(axis=1)
         self.pr_doc = doc_sums / doc_sums.sum()
-        self.pr_topic_doc = predictions / predictions.sum().sum()
         self.pr_doc_topic = predictions / predictions.sum().sum()
 
     def prob_token_topic(self, token=None, topic=None, c_token=None,
@@ -621,10 +620,10 @@ class LDAResults(object):
     @property
     def pr_doc_g_topic(self):
         # Note:  self.pr_topic is computed using a different file than
-        # self.pr_topic_doc....the resultant implied pr_topic series differ
+        # self.pr_doc_topic....the resultant implied pr_topic series differ
         # unless many passes are used.
-        return self.pr_topic_doc.div(self.pr_topic, axis=1)
+        return self.pr_doc_topic.div(self.pr_topic, axis=1)
 
     @property
     def pr_topic_g_doc(self):
-        return self.pr_topic_doc.div(self.pr_doc, axis=0).T
+        return self.pr_doc_topic.div(self.pr_doc, axis=0).T

--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -325,7 +325,6 @@ class LDAResults(object):
         word_sums = topics.sum(axis=1)
         self.pr_token = word_sums / word_sums.sum()
         self.pr_token_topic = topics / self._lambda_word_sums.sum()
-        self.pr_token_topic.index.name = 'token'
 
         # docs & topics
         doc_sums = predictions.sum(axis=1)

--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -318,21 +318,19 @@ class LDAResults(object):
         Others can be derived and appear as "properties"
         (in the decorator sense).
         """
-        topic_sums = topics.sum()
-        self.pr_topic = topic_sums / topic_sums.sum()
+        self._lambda_word_sums = topics.sum()
+        self.pr_topic = self._lambda_word_sums / self._lambda_word_sums.sum()
 
+        # topic tokens
         word_sums = topics.sum(axis=1)
         self.pr_token = word_sums / word_sums.sum()
-        self.pr_topic_token = topics / topics.sum().sum()
+        self.pr_token_topic = topics / self._lambda_word_sums.sum()
+        self.pr_token_topic.index.name = 'token'
 
+        # topic docs
         doc_sums = predictions.sum(axis=1)
         self.pr_doc = doc_sums / doc_sums.sum()
         self.pr_topic_doc = predictions / predictions.sum().sum()
-
-        # New stuff
-        self._lambda_word_sums = topics.sum()
-        self.pr_token_topic = topics / self._lambda_word_sums.sum()
-        self.pr_token_topic.index.name = 'token'
         self.pr_doc_topic = predictions / predictions.sum().sum()
 
     def prob_token_topic(self, token=None, topic=None, c_token=None,
@@ -614,11 +612,11 @@ class LDAResults(object):
 
     @property
     def pr_token_g_topic(self):
-        return self.pr_topic_token.div(self.pr_topic, axis=1)
+        return self.pr_token_topic.div(self.pr_topic, axis=1)
 
     @property
     def pr_topic_g_token(self):
-        return self.pr_topic_token.div(self.pr_token, axis=0).T
+        return self.pr_token_topic.div(self.pr_token, axis=0).T
 
     @property
     def pr_doc_g_topic(self):

--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -325,6 +325,7 @@ class LDAResults(object):
         word_sums = topics.sum(axis=1)
         self.pr_token = word_sums / word_sums.sum()
         self.pr_token_topic = topics / self._lambda_word_sums.sum()
+        self.pr_token_topic.index.name = 'token'
 
         # docs & topics
         doc_sums = predictions.sum(axis=1)


### PR DESCRIPTION
Some cleanup:
   * removed redundant probability data frame in LDAResults
        * cleaned up and made more uniform 
   * removed catdoc from list of unix file converter utils since it's no longer supported and fails on OSX; replaced it with antiword utility
   * test cleanup to reflect above