### PR TITLE
Lda sums

### DIFF
--- a/rosetta/tests/test_text.py
+++ b/rosetta/tests/test_text.py
@@ -212,15 +212,15 @@ class TestLDAResults(unittest.TestCase):
     def test_set_probabilities_marginals(self):
         lda = self.choose_lda()
         pr_doc = pd.Series({'doc1': 3./(3+39+58), 'doc2': (39.+58)/(3+39+58)})
-        assert_series_equal(lda.pr_doc, pr_doc)
+        assert_series_equal(lda.pr_doc, pr_doc, check_names=False)
 
         pr_topic = pd.Series({'topic_0': 4./10, 'topic_1': 6./10})
-        assert_series_equal(lda.pr_topic, pr_topic)
+        assert_series_equal(lda.pr_topic, pr_topic, check_names=False)
 
         # Use the topics file for the token marginals
         # Should be almost equal to results obtained with the predictions file
         pr_token = pd.Series({'w0': 3./10, 'w1': 7./10})
-        assert_series_equal(lda.pr_token, pr_token)
+        assert_series_equal(lda.pr_token, pr_token, check_names=False)
 
     def test_prob_1(self):
         result = self.choose_lda().prob_token_topic(token='w0', c_token=['w1'])

--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -105,6 +105,7 @@ def parse_lda_topics(topics_file, num_topics, max_token_hash=None,
 def _parse_lda_topics_iter(topics_file, num_topics, max_token_hash,
                            normalize):
     fmt = 'topic_%0' + str(len(str(num_topics))) + 'd'
+    fmt_array = [fmt % i for i in xrange(num_topics)]
     # The topics file contains a bunch of informational printout stuff at
     # the top.  Figure out what line this ends on
     with smart_open(topics_file, 'r') as open_file:
@@ -116,20 +117,19 @@ def _parse_lda_topics_iter(topics_file, num_topics, max_token_hash,
                 # If this row raises an exception, then it isn't a valid row
                 # Sometimes trailing space...that's the reason for split()
                 # rather than csv.reader or a direct pandas read.
-                topic_item = pd.Series()
                 split_line = line.split()
                 hash_val = int(split_line[0])
                 if max_token_hash is not None and hash_val > max_token_hash:
                     break
-                topic_weights = [float(item) for item in split_line[1:]]
-                assert len(topic_weights) == num_topics
-                for i, weight in enumerate(topic_weights):
-                    topic_item[fmt % i] = weight
+                topic_weights = np.array(split_line[1:]).astype(float)
+                topic_len = len(topic_weights)
+                assert topic_len == num_topics
                 if normalize:
-                    topic_item = topic_item/topic_item.sum()
-                topic_item['hash_val'] = hash_val
+                    topic_weights = topic_weights/topic_weights.sum()
+                topic_dict = dict(zip(fmt_array, topic_weights))
+                topic_dict.update({'hash_val': hash_val})
                 in_valid_rows = True
-                yield topic_item.to_dict()
+                yield topic_dict
             except (ValueError, IndexError, AssertionError):
                 if in_valid_rows:
                     raise

--- a/rosetta/text/vw_helpers.py
+++ b/rosetta/text/vw_helpers.py
@@ -206,6 +206,7 @@ def parse_lda_predictions(predictions_file, num_topics, start_line,
 def _parse_lda_predictions_iter(predictions_file, num_topics, start_line,
                                 normalize):
     fmt = 'topic_%0' + str(len(str(num_topics))) + 'd'
+    fmt_array = [fmt % i for i in xrange(num_topics)]
     # Use this rather than pandas.read_csv due to inconsistent use of sep
     with smart_open(predictions_file) as open_file:
         # We may have already opened and read this file in order to
@@ -214,16 +215,15 @@ def _parse_lda_predictions_iter(predictions_file, num_topics, start_line,
         for line_num, line in enumerate(open_file):
             if line_num < start_line:
                 continue
-            topic_item = pd.Series()
             split_line = line.split()
-            topic_weights = [float(item) for item in split_line[: -1]]
-            assert len(topic_weights) == num_topics, "Is num_topics correct?"
-            for i, weight in enumerate(topic_weights):
-                topic_item[fmt % i] = weight
+            topic_weights = np.array(split_line[:-1]).astype(float)
+            topic_len = len(topic_weights)
+            assert topic_len == num_topics
             if normalize:
-                topic_item = topic_item/topic_item.sum()
-            topic_item['doc_id'] = split_line[-1]
-            yield topic_item.to_dict()
+                topic_weights = topic_weights/topic_weights.sum()
+            topic_dict = dict(zip(fmt_array, topic_weights))
+            topic_dict.update({'doc_id': split_line[-1]})
+            yield topic_dict
 
 
 class LDAResults(object):


### PR DESCRIPTION
Both [parse_lda_topics()](https://github.com/columbia-applied-data-science/rosetta/blob/master/rosetta/text/vw_helpers.py#L65) and [parse_lda_predictions()](https://github.com/columbia-applied-data-science/rosetta/blob/master/rosetta/text/vw_helpers.py#L172) were painfully slow. Most (~90%) of this was due to unnecessary formatting and re-casting on every iteration. 

Speedups on this branch, using 

```bash
time python lda_sums_test.py
```

in terminal are the following:

for a 1mil row predictions.dat file (200k unique doc ids from vw lda run 5 passes, 10 topics) current branch running

```python
import rosetta.text.vw_helpers as ros_vw_h

predictions_file = '/tmp/prediction_large.dat'

num_topics=10

start_line = ros_vw_h.find_start_line_lda_predictions(predictions_file, num_topics)
pred_iter = ros_vw_h.parse_lda_predictions(predictions_file, num_topics, start_line, normalize=False,
                                                                       get_iter=False)
```

gets
 
```bash
real	0m5.092s
user	0m4.628s
sys	0m0.465s
```

vs 

```bash
real	10m49.159s
user	10m46.165s
sys	0m2.182s
```

on the master branch. (Note: the fine_start_line() wasn't altered between branches and is relatively fast compared to the parser, i.e. ~1.5s) 


for a 30k row topics.dat file (same lda run as above) current branch running

```python 
import rosetta.text.vw_helpers as ros_vw_h

topics_file = '/tmp/topics_large.dat'

topics_iter = ros_vw_h.parse_lda_topics(topics_file, num_topics,
                                                                  normalize=False, get_iter=False)

```

get

```bash
real	0m1.461s
user	0m1.219s
sys	0m0.248s
```

vs

```bash
real	1m48.375s
user	1m47.796s
sys	0m0.505s
```

on the master branch. 


You can run kernprof to see line by line profile comparisons. The differences overall are quite significant in both time and cpu load.... 


Aside: due to a name/indexing [bug](https://github.com/pydata/pandas/issues/9943) in pandas 0.16.2+ which is not going to be fixed until 0.17 some tests started failing after a latest update. Probably the best for now is to simply ignore the name check in assert_series_equal in tests; this doesn't alter the validity of the tests in question.