### PR TITLE
Separate streaming and database streaming.  Python 3-ify

### DIFF
--- a/rosetta/common.py
+++ b/rosetta/common.py
@@ -1,7 +1,7 @@
 """
 Common functions/classes for dataprep.
 """
-from __future__ import print_function
+from __future__ import division, print_function, unicode_literals
 import numpy as np
 try:
     import cPickle

--- a/rosetta/common.py
+++ b/rosetta/common.py
@@ -1,11 +1,16 @@
 """
 Common functions/classes for dataprep.
 """
+from __future__ import print_function
 import numpy as np
-import cPickle
-import itertools
-import os
-import sys
+try:
+    import cPickle
+except ImportError:
+    import pickle as cPickle
+try:
+    from itertools import izip_longest
+except ImportError:
+    from itertools import zip_longest as izip_longest
 import functools
 
 from collections import defaultdict
@@ -206,9 +211,9 @@ def printdict(d, max_print_len=None):
     for key, value in d.iteritems():
         s += str(key) + ': ' + str(value) + '\n'
     if max_print_len:
-        print s[:max_print_len]
+        print(s[:max_print_len])
     else:
-        print s
+        print(s)
 
 
 ###############################################################################
@@ -293,7 +298,7 @@ def grouper(iterable, chunksize, fillvalue=None):
     """
     args = [iter(iterable)] * chunksize
 
-    return itertools.izip_longest(fillvalue=fillvalue, *args)
+    return izip_longest(fillvalue=fillvalue, *args)
 
 
 def compose(*functions):

--- a/rosetta/common_abc.py
+++ b/rosetta/common_abc.py
@@ -2,9 +2,12 @@
 Common abstract base classes (or mixins..if we get krazy) that will be shared
 across modules.
 """
-import cPickle
+try:
+    import cPickle
+except ImportError:
+    import pickle as cPickle
 
-from common import smart_open
+from .common import smart_open
 
 
 class SaveLoad(object):

--- a/rosetta/parallel/parallel_easy.py
+++ b/rosetta/parallel/parallel_easy.py
@@ -10,7 +10,10 @@ Functions to assist in parallel processing with Python 2.7.
 import itertools
 from multiprocessing import cpu_count, Pool, Process, Manager, Lock
 from multiprocessing.pool import IMapUnorderedIterator, IMapIterator
-import cPickle
+try:
+    import cPickle
+except ImportError:
+    import pickle as cPickle
 import sys
 
 

--- a/rosetta/tests/test_streamer.py
+++ b/rosetta/tests/test_streamer.py
@@ -6,7 +6,7 @@ from scipy import sparse
 
 from rosetta import TokenizerBasic
 from rosetta.text.streamers import TextFileStreamer, TextIterStreamer
-from rosetta.text.streamers import MySQLStreamer, MongoStreamer
+from rosetta.text.database_streamers import MySQLStreamer, MongoStreamer
 
 try:
     import MySQLdb
@@ -16,14 +16,12 @@ except ImportError:
     HAS_MYSQLDB = False
 
 
-from rosetta.common import DocIDError, TokenError
-
-
 class TestTextFileStreamer(unittest.TestCase):
     def setUp(self):
         self.test_path = os.path.abspath('./rosetta/tests')
         self.testdata_path = os.path.join(self.test_path, 'temp')
-        ###create some temp files to work with
+
+        # create some temp files to work with
         self.doc1 = os.path.join(self.testdata_path, 'doc1.txt')
         self.doc2 = os.path.join(self.testdata_path, 'doc2.txt')
         with open(self.doc1, 'w') as f:
@@ -32,9 +30,8 @@ class TestTextFileStreamer(unittest.TestCase):
             f.write('set for success\n')
         self.tokenizer = TokenizerBasic()
 
-
     def test_info_stream(self):
-        stream = TextFileStreamer(path_list = [self.doc1, self.doc2],
+        stream = TextFileStreamer(path_list=[self.doc1, self.doc2],
                                   tokenizer=self.tokenizer)
         token_benchmark = [['doomed', 'failure'],
                            ['set', 'success']]
@@ -50,7 +47,7 @@ class TestTextFileStreamer(unittest.TestCase):
         self.assertEqual(text_benchmark, text_result)
 
     def test_token_stream(self):
-        stream = TextFileStreamer(path_list = [self.doc1, self.doc2],
+        stream = TextFileStreamer(path_list=[self.doc1, self.doc2],
                                   tokenizer=self.tokenizer)
         token_benchmark = [['doomed', 'failure'],
                            ['set', 'success']]
@@ -63,7 +60,7 @@ class TestTextFileStreamer(unittest.TestCase):
         self.assertEqual(id_benchmark, stream.__dict__['doc_id_cache'])
 
     def test_to_vw(self):
-        stream = TextFileStreamer(path_list = [self.doc1, self.doc2],
+        stream = TextFileStreamer(path_list=[self.doc1, self.doc2],
                                   tokenizer=self.tokenizer)
         result = StringIO()
         stream.to_vw(result)
@@ -72,7 +69,7 @@ class TestTextFileStreamer(unittest.TestCase):
         self.assertEqual(benchmark, result.getvalue())
 
     def test_to_scipyspare(self):
-        stream = TextFileStreamer(path_list = [self.doc1, self.doc2],
+        stream = TextFileStreamer(path_list=[self.doc1, self.doc2],
                                   tokenizer=self.tokenizer)
 
         result = stream.to_scipysparse()
@@ -122,23 +119,15 @@ class TestTextIterStreamer(unittest.TestCase):
         self.assertEqual(token_benchmark, token_result)
         self.assertEqual(id_benchmark, stream.__dict__['doc_id_cache'])
 
-
-    def test_to_scipyspare(self):
-        stream = TextFileStreamer(path_list = [self.doc1, self.doc2],
-                                  tokenizer=self.tokenizer)
-
-        result = stream.to_scipysparse()
-        benchmark = sparse.csr_matrix([[1, 1, 0, 0], [0, 0, 1, 1]])
-
     def test_to_vw(self):
         stream = TextIterStreamer(text_iter=self.text_iter,
                                   tokenizer=self.tokenizer)
         stream.to_vw(open(self.temp_vw_path, 'w'))
-        result  = open(self.temp_vw_path).read()
+        result = open(self.temp_vw_path).read()
         benchmark = " 1 a| failure:1 doomed:1\n 1 1| set:1 success:1\n"
         self.assertEqual(benchmark, result)
 
-    def test_to_scipyspare(self):
+    def test_to_scipysparse(self):
         stream = TextIterStreamer(text_iter=self.text_iter,
                                   tokenizer=self.tokenizer)
 
@@ -150,7 +139,8 @@ class TestTextIterStreamer(unittest.TestCase):
 
     def tearDown(self):
         os.remove(self.temp_vw_path) if (
-                os.path.exists(self.temp_vw_path)) else None
+            os.path.exists(self.temp_vw_path)) else None
+
 
 class TestMySQLStreamer(unittest.TestCase):
     def setUp(self):
@@ -216,7 +206,7 @@ class TestMySQLStreamer(unittest.TestCase):
                                tokenizer=self.tokenizer)
         stream.cursor = self.mock_cursor
         stream.to_vw(open(self.temp_vw_path, 'w'))
-        result  = open(self.temp_vw_path).read()
+        result = open(self.temp_vw_path).read()
 
         benchmark = " 1 a| failure:1 doomed:1\n 1 1| set:1 success:1\n"
         self.assertEqual(benchmark, result)
@@ -235,7 +225,8 @@ class TestMySQLStreamer(unittest.TestCase):
 
     def tearDown(self):
         os.remove(self.temp_vw_path) if (
-                os.path.exists(self.temp_vw_path)) else None
+            os.path.exists(self.temp_vw_path)) else None
+
 
 class TestMongoStreamer(unittest.TestCase):
     def setUp(self):
@@ -301,7 +292,7 @@ class TestMongoStreamer(unittest.TestCase):
                                tokenizer=self.tokenizer)
         stream.cursor = self.mock_cursor
         stream.to_vw(open(self.temp_vw_path, 'w'))
-        result  = open(self.temp_vw_path).read()
+        result = open(self.temp_vw_path).read()
 
         benchmark = " 1 a| failure:1 doomed:1\n 1 1| set:1 success:1\n"
         self.assertEqual(benchmark, result)
@@ -319,4 +310,4 @@ class TestMongoStreamer(unittest.TestCase):
 
     def tearDown(self):
         os.remove(self.temp_vw_path) if (
-                os.path.exists(self.temp_vw_path)) else None
+            os.path.exists(self.temp_vw_path)) else None

--- a/rosetta/text/database_streamers.py
+++ b/rosetta/text/database_streamers.py
@@ -1,0 +1,245 @@
+"""
+Classes for streaming tokens/info from databases
+"""
+import abc
+
+try:
+    import MySQLdb
+    import MySQLdb.cursors
+    HAS_MYSQLDB = True
+except ImportError:
+    HAS_MYSQLDB = False
+
+
+from streamers import BaseStreamer
+import pymongo
+
+from .. import common
+from rosetta.text import text_processors
+
+
+class DBStreamer(BaseStreamer):
+    """
+    Database streamer base class
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(
+            self, db_setup, tokenizer=None, tokenizer_func=None):
+        """
+        Parameters
+        ----------
+        db_setup: A dictionary containing parameters needed to connect to, and
+            query the database.  The required parameters are documented in each
+            subclass, but at minimum you will need information about the host,
+            username/password, and the query that will be executed.  The query
+            must return a 'text' field in its dictionary.
+        tokenizer : Subclass of BaseTokenizer
+            Should have a text_to_token_list method.  Try using MakeTokenizer
+            to convert a function to a valid tokenizer.
+        tokenizer_func : Function
+            Transforms a string (representing one file) to a list of strings
+            (the 'tokens').
+        """
+        self.db_setup = db_setup
+        self.tokenizer = tokenizer
+        self.tokenizer_func = tokenizer_func
+        self.cursor = None
+
+        assert (tokenizer is None) or (tokenizer_func is None)
+        if tokenizer_func:
+            self.tokenizer = text_processors.MakeTokenizer(tokenizer_func)
+
+    @abc.abstractmethod
+    def connect(self):
+        """
+        Open connection to database.
+        sets the classes cursor object.
+        """
+        return
+
+    @abc.abstractmethod
+    def disconnect(self):
+        """
+        Close connection to database
+        """
+        return
+
+    @abc.abstractmethod
+    def iterate_over_query(self):
+        """
+        Return an iterator over query result.
+        We suggest that the entire query result not be returned and that
+        iteration is controlled on server side, but this method does not
+        guarantee that.  This method must return a dictionary, which at
+        least has the key 'text' in it, containing the next to be tokenized.
+        """
+        return
+
+    def record_stream(self):
+        for info in self.iterate_over_query():
+            yield info
+
+    def info_stream(self):
+        """
+        Yields a dict from self.executing the query as well as "tokens".
+        """
+        for info in self.record_stream():
+            info['tokens'] = self.tokenizer.text_to_token_list(info['text'])
+            yield info
+
+
+class MySQLStreamer(DBStreamer):
+    """
+    Subclass of DBStreamer to connect to a MySQL database and iterate over
+    query results.  db_setup is expected to be a dictionary containing
+    host, user, password, database, and query.  The query itself must return
+    a column named text.
+
+    Example:
+        db_setup = {}
+        db_setup['host'] = 'hostname'
+        db_setup['user'] = 'username'
+        db_setup['password'] = 'password'
+        db_setup['database'] = 'database'
+        db_setup['query'] = 'select
+                                id as doc_id,
+                                body as text
+                             from tablename
+                             where length(body) > 100'
+
+        my_tokenizer = TokenizerBasic()
+        stream = MySQLStreamer(db_setup=db_setup, tokenizer=my_tokenizer)
+
+        for text in stream.info_stream(cache_list=['doc_id']):
+            print text['doc_id'], text['tokens']
+    """
+    def __init__(self, *args, **kwargs):
+        if not HAS_MYSQLDB:
+            raise ImportError("MySQLdb was not importable, therefore\
+                MySQLStreamer cannot be used.")
+        super(MySQLStreamer, self).__init__(*args, **kwargs)
+
+    def connect(self):
+        try:
+            _host = self.db_setup['host']
+            _user = self.db_setup['user']
+            _password = self.db_setup['password']
+            _db = self.db_setup['database']
+        except:
+            raise common.BadDataError("MySQLStreamer expects db_setup to have \
+                        host, user, password, and database fields")
+        connection = MySQLdb.connect(
+            host=_host, user=_user,
+            passwd=_password, db=_db,
+            cursorclass=MySQLdb.cursors.SSDictCursor)
+        self.cursor = connection.cursor()
+
+    def disconnect(self):
+        if self.cursor:
+            self.cursor.close()
+        self.cursor = None
+
+    def iterate_over_query(self):
+        if not self.cursor:
+            self.connect()
+        try:
+            _query = self.db_setup['query']
+        except:
+            raise common.BadDataError("MySQLStreamer expects db_setup \
+                                      to have a query field")
+        self.cursor.execute(_query)
+        for result in self.cursor:
+            if 'text' not in result:
+                raise common.BadDataError("The query must return a text field")
+            yield result
+
+
+class MongoStreamer(DBStreamer):
+    """
+    Subclass of DBStreamer to connect to a Mongo database and iterate over
+    query results.  db_setup is expected to be a dictionary containing
+    host, database, collection, query, and text_key.  Additionally an optional
+    limit parameter is allowed.
+    The query itself must return a column named text_key which is passed on
+    as 'text' to the iterator.
+    In addition, because it is difficult to rename mongo fields (similar
+    to the SQL 'AS' syntax), we allow a translation dictionary to be
+    passed in, which translates keys in the mongo dictionary result names
+    k to be passed into the result as v for key value pairs {k : v}.
+    Currently we don't deal with nested documents.
+
+    Example:
+
+        db_setup = {}
+        db_setup['host'] = 'localhost'
+        db_setup['database'] = 'places'
+        db_setup['collection'] = 'opentable'
+        db_setup['query'] = {}
+        db_setup['limit'] = 5
+        db_setup['text_key'] = 'desc'
+        db_setup['translations'] = {'_id' : 'doc_id'}
+
+        # In this example, we assume that the collection has a field named
+        # desc, holding the text to be analyzed, and a field named _id which
+        # will be translated to doc_id and stored in the cache.
+
+        my_tokenizer = TokenizerBasic()
+        stream = MongoStreamer(db_setup=db_setup, tokenizer=my_tokenizer)
+
+        for text in stream.info_stream(cache_list=['doc_id']):
+            print text['doc_id'], text['tokens']
+    """
+    def connect(self):
+        try:
+            _host = self.db_setup['host']
+            _db = self.db_setup['database']
+            _col = self.db_setup['collection']
+            if 'port' in self.db_setup:
+                _port = self.db_setup['port']
+            else:
+                _port = None
+        except:
+            raise common.BadDataError("MongoStreamer expects db_setup to have \
+                        host and database fields")
+
+        client = pymongo.MongoClient(_host, _port)
+        db = client[_db]
+        col = db[_col]
+        self.cursor = col
+
+    def disconnect(self):
+        self.cursor = None
+
+    def iterate_over_query(self):
+        if not self.cursor:
+            self.connect()
+        try:
+            _query = self.db_setup['query']
+            _text_key = self.db_setup['text_key']
+            if 'limit' in self.db_setup:
+                _limit = self.db_setup['limit']
+            else:
+                _limit = None
+            if 'translations' in self.db_setup:
+                _translate = self.db_setup['translations']
+            else:
+                _translate = None
+        except:
+            raise common.BadDataError("MySQLStreamer expects db_setup \
+                                      to have a query and text_key field")
+
+        results = self.cursor.find(_query)
+
+        if _limit:
+            results = results.limit(_limit)
+
+        for result in results:
+            if _text_key not in result:
+                raise common.BadDataError("The query must return the \
+                                           specified text field")
+            result['text'] = result[_text_key]
+            if _translate:
+                for k, v in _translate.items():
+                    result[v] = result[k]
+            yield result

--- a/rosetta/text/nlp.py
+++ b/rosetta/text/nlp.py
@@ -1,6 +1,10 @@
 import re
 
-from itertools import izip, chain
+try:
+    from itertools import izip, chain
+except ImportError:
+    from itertools import chain
+    izip = zip
 
 
 ###############################################################################
@@ -29,7 +33,7 @@ def word_tokenize(text, L=1, numeric=True):
     numeric : bool, True if you want to include numerics
     """
     text = re.sub(
-        r'(?:\s|\[|\]|\(|\)|\{|\}|;|,|\.(\s|$)|:|\n|\r|\?|\!|\"|\-)', r'  ', 
+        r'(?:\s|\[|\]|\(|\)|\{|\}|;|,|\.(\s|$)|:|\n|\r|\?|\!|\"|\-)', r'  ',
         text)
     if numeric:
         word_list = re.findall(
@@ -37,7 +41,7 @@ def word_tokenize(text, L=1, numeric=True):
             (?:(?<=.|\s)[A-Z]\.)+)(?:\s|$)' % (L, L), text)
     else:
         word_list = re.findall(
-            r'(?:\s|^)([A-Za-z\.\'&]{%s,}|(?:(?<=.|\s)[A-Z]\.)+)(?:\s|$)' % L, 
+            r'(?:\s|^)([A-Za-z\.\'&]{%s,}|(?:(?<=.|\s)[A-Z]\.)+)(?:\s|$)' % L,
             text)
 
     return word_list

--- a/rosetta/text/streamers.py
+++ b/rosetta/text/streamers.py
@@ -10,15 +10,6 @@ import sys
 import os
 from scipy import sparse
 
-try:
-    import MySQLdb
-    import MySQLdb.cursors
-    HAS_MYSQLDB = True
-except ImportError:
-    HAS_MYSQLDB = False
-
-import pymongo
-
 from rosetta.parallel.parallel_easy import imap_easy, parallel_apply
 
 from .. import common
@@ -91,7 +82,7 @@ class BaseStreamer(object):
         return self.single_stream('tokens', cache_list=cache_list, **kwargs)
 
     def to_vw(self, out_stream=sys.stdout, n_jobs=1, raise_on_bad_id=True,
-            cache_list=None):
+              cache_list=None):
         """
         Write our filestream to a VW (Vowpal Wabbit) formatted file.
 
@@ -276,9 +267,9 @@ class TextFileStreamer(BaseStreamer):
     For streaming from text files.
     """
     def __init__(
-        self, text_base_path=None, path_list=None, file_type='*',
-        name_strip=r'\..*', tokenizer=None, tokenizer_func=None, limit=None,
-        shuffle=True):
+            self, text_base_path=None, path_list=None, file_type='*',
+            name_strip=r'\..*', tokenizer=None, tokenizer_func=None, limit=None,
+            shuffle=True):
         """
         Parameters
         ----------
@@ -366,7 +357,8 @@ class TextFileStreamer(BaseStreamer):
         """
         Retrieves os.stats info for file.
         """
-        return {'mtime': os.path.getmtime(path), 'atime': os.path.getatime(path),
+        return {'mtime': os.path.getmtime(path),
+                'atime': os.path.getatime(path),
                 'size': os.path.getsize(path)}
 
     def record_stream(self, paths=None, doc_id=None, limit=None):
@@ -403,7 +395,7 @@ class TextFileStreamer(BaseStreamer):
                     (onepath, strip_ext=False))
                 stat_dict = self._file_stat(onepath)
                 info_dict = {'text': text, 'cached_path': onepath,
-                        'doc_id': doc_id}
+                             'doc_id': doc_id}
                 info_dict.update(stat_dict)
                 if self.tokenizer:
                     info_dict['tokens'] = (
@@ -463,8 +455,9 @@ class TextIterStreamer(BaseStreamer):
         Parameters
         ----------
         text_iter : iterator or iterable of dictionaries
-            Each dict must contain key:value "text": text_string, but can contain
-            other metadata key:values for cacheing (ex/ see self.token_stream).
+            Each dict must contain key:value "text": text_string,
+            but can contain other metadata key:values for cacheing
+            (ex/ see self.token_stream).
         tokenizer : Subclass of BaseTokenizer
             Should have a text_to_token_list method.  Try using MakeTokenizer
             to convert a function to a valid tokenizer.
@@ -494,233 +487,6 @@ class TextIterStreamer(BaseStreamer):
         for info in self.record_stream():
             info['tokens'] = self.tokenizer.text_to_token_list(info['text'])
             yield info
-
-
-class DBStreamer(BaseStreamer):
-    """
-    Database streamer base class
-    """
-    __metaclass__ = abc.ABCMeta
-
-    def __init__(
-            self, db_setup, tokenizer=None, tokenizer_func=None):
-        """
-        Parameters
-        ----------
-        db_setup: A dictionary containing parameters needed to connect to, and
-            query the database.  The required parameters are documented in each
-            subclass, but at minimum you will need information about the host,
-            username/password, and the query that will be executed.  The query
-            must return a 'text' field in its dictionary.
-        tokenizer : Subclass of BaseTokenizer
-            Should have a text_to_token_list method.  Try using MakeTokenizer
-            to convert a function to a valid tokenizer.
-        tokenizer_func : Function
-            Transforms a string (representing one file) to a list of strings
-            (the 'tokens').
-        """
-        self.db_setup = db_setup
-        self.tokenizer = tokenizer
-        self.tokenizer_func = tokenizer_func
-        self.cursor = None
-
-        assert (tokenizer is None) or (tokenizer_func is None)
-        if tokenizer_func:
-            self.tokenizer = text_processors.MakeTokenizer(tokenizer_func)
-
-    @abc.abstractmethod
-    def connect(self):
-        """
-        Open connection to database.
-        sets the classes cursor object.
-        """
-        return
-
-    @abc.abstractmethod
-    def disconnect(self):
-        """
-        Close connection to database
-        """
-        return
-
-    @abc.abstractmethod
-    def iterate_over_query(self):
-        """
-        Return an iterator over query result.
-        We suggest that the entire query result not be returned and that
-        iteration is controlled on server side, but this method does not
-        guarantee that.  This method must return a dictionary, which at
-        least has the key 'text' in it, containing the next to be tokenized.
-        """
-        return
-
-    def record_stream(self):
-        for info in self.iterate_over_query():
-            yield info
-
-    def info_stream(self):
-        """
-        Yields a dict from self.executing the query as well as "tokens".
-        """
-        for info in self.record_stream():
-            info['tokens'] = self.tokenizer.text_to_token_list(info['text'])
-            yield info
-
-
-class MySQLStreamer(DBStreamer):
-    """
-    Subclass of DBStreamer to connect to a MySQL database and iterate over
-    query results.  db_setup is expected to be a dictionary containing
-    host, user, password, database, and query.  The query itself must return
-    a column named text.
-
-    Example:
-        db_setup = {}
-        db_setup['host'] = 'hostname'
-        db_setup['user'] = 'username'
-        db_setup['password'] = 'password'
-        db_setup['database'] = 'database'
-        db_setup['query'] = 'select
-                                id as doc_id,
-                                body as text
-                             from tablename
-                             where length(body) > 100'
-
-        my_tokenizer = TokenizerBasic()
-        stream = MySQLStreamer(db_setup=db_setup, tokenizer=my_tokenizer)
-
-        for text in stream.info_stream(cache_list=['doc_id']):
-            print text['doc_id'], text['tokens']
-    """
-    def __init__(self, *args, **kwargs):
-        if not HAS_MYSQLDB:
-            raise ImportError("MySQLdb was not importable, therefore\
-                MySQLStreamer cannot be used.")
-        super(MySQLStreamer, self).__init__(*args, **kwargs)
-
-    def connect(self):
-        try:
-            _host = self.db_setup['host']
-            _user = self.db_setup['user']
-            _password = self.db_setup['password']
-            _db = self.db_setup['database']
-        except:
-            raise common.BadDataError("MySQLStreamer expects db_setup to have \
-                        host, user, password, and database fields")
-        connection = MySQLdb.connect(
-            host=_host, user=_user,
-            passwd=_password, db=_db,
-            cursorclass=MySQLdb.cursors.SSDictCursor)
-        self.cursor = connection.cursor()
-
-    def disconnect(self):
-        if self.cursor:
-            self.cursor.close()
-        self.cursor = None
-
-    def iterate_over_query(self):
-        if not self.cursor:
-            self.connect()
-        try:
-            _query = self.db_setup['query']
-        except:
-            raise common.BadDataError("MySQLStreamer expects db_setup \
-                                      to have a query field")
-        self.cursor.execute(_query)
-        for result in self.cursor:
-            if 'text' not in result:
-                raise common.BadDataError("The query must return a text field")
-            yield result
-
-
-class MongoStreamer(DBStreamer):
-    """
-    Subclass of DBStreamer to connect to a Mongo database and iterate over
-    query results.  db_setup is expected to be a dictionary containing
-    host, database, collection, query, and text_key.  Additionally an optional
-    limit parameter is allowed.
-    The query itself must return a column named text_key which is passed on
-    as 'text' to the iterator.
-    In addition, because it is difficult to rename mongo fields (similar
-    to the SQL 'AS' syntax), we allow a translation dictionary to be
-    passed in, which translates keys in the mongo dictionary result names
-    k to be passed into the result as v for key value pairs {k : v}.
-    Currently we don't deal with nested documents.
-
-    Example:
-
-        db_setup = {}
-        db_setup['host'] = 'localhost'
-        db_setup['database'] = 'places'
-        db_setup['collection'] = 'opentable'
-        db_setup['query'] = {}
-        db_setup['limit'] = 5
-        db_setup['text_key'] = 'desc'
-        db_setup['translations'] = {'_id' : 'doc_id'}
-
-        # In this example, we assume that the collection has a field named
-        # desc, holding the text to be analyzed, and a field named _id which
-        # will be translated to doc_id and stored in the cache.
-
-        my_tokenizer = TokenizerBasic()
-        stream = MongoStreamer(db_setup=db_setup, tokenizer=my_tokenizer)
-
-        for text in stream.info_stream(cache_list=['doc_id']):
-            print text['doc_id'], text['tokens']
-    """
-    def connect(self):
-        try:
-            _host = self.db_setup['host']
-            _db = self.db_setup['database']
-            _col = self.db_setup['collection']
-            if 'port' in self.db_setup:
-                _port = self.db_setup['port']
-            else:
-                _port = None
-        except:
-            raise common.BadDataError("MongoStreamer expects db_setup to have \
-                        host and database fields")
-
-        client = pymongo.MongoClient(_host, _port)
-        db = client[_db]
-        col = db[_col]
-        self.cursor = col
-
-    def disconnect(self):
-        self.cursor = None
-
-    def iterate_over_query(self):
-        if not self.cursor:
-            self.connect()
-        try:
-            _query = self.db_setup['query']
-            _text_key = self.db_setup['text_key']
-            if 'limit' in self.db_setup:
-                _limit = self.db_setup['limit']
-            else:
-                _limit = None
-            if 'translations' in self.db_setup:
-                _translate = self.db_setup['translations']
-            else:
-                _translate = None
-        except:
-            raise common.BadDataError("MySQLStreamer expects db_setup \
-                                      to have a query and text_key field")
-
-        results = self.cursor.find(_query)
-
-        if _limit:
-            results = results.limit(_limit)
-
-        for result in results:
-            if _text_key not in result:
-                raise common.BadDataError("The query must return the \
-                                           specified text field")
-            result['text'] = result[_text_key]
-            if _translate:
-                for k, v in _translate.items():
-                    result[v] = result[k]
-            yield result
 
 
 def _group_to_sstr(streamer, formatter, raise_on_bad_id, path_group):
@@ -755,7 +521,7 @@ def _group_to_sstr(streamer, formatter, raise_on_bad_id, path_group):
 
 
 def _to_sstr(record_dict, tokenizer, formatter, raise_on_bad_id,
-        streamer, cache_list=None):
+             streamer, cache_list=None):
     """
     Yield a list of sstr's (sparse string representations); takes yield
     instances of STREAMER.record_stream(), tokenizes the text, get 'doc_id'
@@ -771,9 +537,9 @@ def _to_sstr(record_dict, tokenizer, formatter, raise_on_bad_id,
             feature_values, importance=1, doc_id=doc_id)
         for cache_item in cache_list:
             streamer.__dict__[cache_item + '_cache'].append(
-                    record_dict[cache_item])
+                record_dict[cache_item])
     except DocIDError as e:
-        msg = e.message + "\doc_id = %s\n" % info_dict['doc_id']
+        msg = e.message + "\doc_id = %s\n" % record_dict['doc_id']
         if raise_on_bad_id:
             raise DocIDError(msg)
         else:

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,18 @@ DESCRIPTION = (
     "processing")
 
 SCRIPTS = [
-    'rosetta/cmdutils/' + name for name in 
+    'rosetta/cmdutils/' + name for name in
     ['concat_csv.py', 'cut.py', 'join_csv.py',
     'row_filter.py', 'split.py', 'subsample.py',
     'files_to_vw.py', 'filter_sfile.py', 'groupby_reduce.py']]
 
 PACKAGES =  ['rosetta'] + [
-    'rosetta.' + name for name in 
+    'rosetta.' + name for name in
     ['cmdutils', 'modeling', 'parallel', 'text', 'workflow']]
 
 
 #PY_MODULES =  ['rosetta'] + [
-#    'rosetta/' + name for name in 
+#    'rosetta/' + name for name in
 #    ['cmdutils', 'modeling', 'parallel', 'text', 'workflow']]
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,6 @@ PACKAGES =  ['rosetta'] + [
     'rosetta.' + name for name in
     ['cmdutils', 'modeling', 'parallel', 'text', 'workflow']]
 
-
-#PY_MODULES =  ['rosetta'] + [
-#    'rosetta/' + name for name in
-#    ['cmdutils', 'modeling', 'parallel', 'text', 'workflow']]
-
-
 setup(
     name=DISTNAME,
     version='0.2.5',


### PR DESCRIPTION
This would be a breaking change since it separates `text.streamers` from `text.database_streamers`.  The difference is that people can use `rosetta.text` without having to have database dependencies like `pymongo` and `MySQL-python` (the latter of which requires a mysql client dependency, which is kind of annoying to carry around if you aren't using mysql).  This would partially address people's install issues (e.g. https://github.com/columbia-applied-data-science/rosetta/issues/48)

The other changes are so that `rosetta` installs using into `python3` environments.  There are a couple slightly dirty solutions here, implemented by catching `ImportError`, but for the most part `rosetta` is python3 compatible so it might as well work there. 