### PR TITLE
Add a min/max token streaming filter

### DIFF
--- a/rosetta/text/streaming_filters.py
+++ b/rosetta/text/streaming_filters.py
@@ -195,7 +195,7 @@ def get_min_max_token_filter(min_tokens, max_tokens):
     If the goal is to only keep documents whose final token count is greater
     than min_tokens, this filter should be used last.
     """
-    def min_max_token_filter(record_dict, min_tokens, max_tokens):
+    def min_max_token_filter(record_dict):
         num = len(record_dict['feature_values'])
         keep_doc = (num >= min_tokens and num <= max_tokens)
         return keep_doc

--- a/rosetta/text/streaming_filters.py
+++ b/rosetta/text/streaming_filters.py
@@ -171,3 +171,32 @@ def get_token_to_id_filter(sfile_filter):
         keep_doc = True
         return keep_doc
     return token_to_id_filter
+
+
+def get_min_max_token_filter(min_tokens, max_tokens):
+    """
+    This function returns a filter which drops any document whose total number
+    of tokens is less than min_tokens or greater than that of max_tokens.
+
+    This filter does not alter record_dict, but instead returns either true or
+    false indicating whether to document should be kept or not.
+
+    Parameters
+    ----------
+    min_tokens : numeric
+    max_tokens : numeric
+
+    Returns
+    -------
+    min_max_token_filter : function
+
+    Note
+    ----
+    If the goal is to only keep documents whose final token count is greater
+    than min_tokens, this filter should be used last.
+    """
+    def min_max_token_filter(record_dict, min_tokens, max_tokens):
+        num = len(record_dict['feature_values'])
+        keep_doc = (num >= min_tokens and num <= max_tokens)
+        return keep_doc
+    return min_max_token_filter

--- a/rosetta/text/text_processors.py
+++ b/rosetta/text/text_processors.py
@@ -660,7 +660,7 @@ class SFileFilter(SaveLoad):
 
     def filter_sfile(
         self, infile, outfile, doc_id_list=None, enforce_all_doc_id=True,
-        min_tf_idf=0, filters=None):
+        min_tf_idf=0, min_tokens=0, max_tokens=10000, filters=None):
         """
         Alter an sfile by converting tokens to id values, and removing tokens
         not in self.token2id.  Optionally filters on doc_id, tf_idf and
@@ -687,6 +687,10 @@ class SFileFilter(SaveLoad):
                 (2) idf(t, D) = log (N / M), where N is the total number of
                     documents in D and M is the number of documents in D which
                     contain the token t. The logarithm is base e.
+        min_tokens : int
+            min number of tokens a doc can have
+        max_tokens : int
+            max number of tokens a doc can have
         filters : iterable over functions
             Each function must take a record_dict as a parameter and return a
             boolean. The record_dict may (and usually should) be altered in
@@ -730,7 +734,9 @@ class SFileFilter(SaveLoad):
 
         # The token_to_id_filter should be run last so that only the necessary
         # conversions are made.
-        postfilters = [streaming_filters.get_token_to_id_filter(self)]
+        postfilters = [streaming_filters.get_token_to_id_filter(self),
+                       streaming_filters.get_min_max_token_filter(min_tokens,
+                                                                  max_tokens)]
 
         filters = prefilters + filters + postfilters
 


### PR DESCRIPTION
We saw oddities running `VW` when there were 0 tokens or quite a few tokens (Segfaults, malloc errors, a general mess).  This gives us a shot at filtering out those docs before they make it into `VW` model building.

joint w/ @dkrasner 